### PR TITLE
Fix ICS timestamp formatting

### DIFF
--- a/app/api/ics/route.ts
+++ b/app/api/ics/route.ts
@@ -1,4 +1,27 @@
-import { NextResponse } from 'next/server';function esc(s:string){return s.replace(/,/g,'\\,').replace(/;/g,'\\;').replace(/\n/g,'\\n')}export async function GET(req:Request){const {searchParams}=new URL(req.url);const title=searchParams.get('title')||'CLM Service';const desc=searchParams.get('desc')||'';const start=searchParams.get('start');const end=searchParams.get('end')||start||'';const loc=searchParams.get('loc')||'Christ Like Ministries, Birmingham, AL';if(!start)return new NextResponse('Missing start',{status:400});const dt=(x:string)=>x.replace(/[-:]/g,'').replace('.000','').replace('Z','Z');const ics=`BEGIN:VCALENDAR
+import { NextResponse } from 'next/server';
+
+function esc(s: string) {
+  return s
+    .replace(/,/g, '\\,')
+    .replace(/;/g, '\\;')
+    .replace(/\n/g, '\\n');
+}
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const title = searchParams.get('title') || 'CLM Service';
+  const desc = searchParams.get('desc') || '';
+  const start = searchParams.get('start');
+  const end = searchParams.get('end') || start || '';
+  const loc =
+    searchParams.get('loc') || 'Christ Like Ministries, Birmingham, AL';
+
+  if (!start) return new NextResponse('Missing start', { status: 400 });
+
+  const dt = (x: string) =>
+    x.replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z');
+
+  const ics = `BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:-//CLM//Schedule//EN
 BEGIN:VEVENT
@@ -10,4 +33,12 @@ SUMMARY:${esc(title)}
 DESCRIPTION:${esc(desc)}
 LOCATION:${esc(loc)}
 END:VEVENT
-END:VCALENDAR`.replace(/\n/g,'\r\n');return new NextResponse(ics,{headers:{'Content-Type':'text/calendar; charset=utf-8','Content-Disposition':'attachment; filename=event.ics'}})}
+END:VCALENDAR`.replace(/\n/g, '\r\n');
+
+  return new NextResponse(ics, {
+    headers: {
+      'Content-Type': 'text/calendar; charset=utf-8',
+      'Content-Disposition': 'attachment; filename=event.ics',
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- ensure ICS timestamps drop millisecond precision for standards compliance

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f5919d9f88322a116e257fcc44cfe