### PR TITLE
Add welcome intro banner

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -46,6 +46,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <Lightning />  {/* ⚡️ subtle, random strikes behind content */}
         <AnnouncementsBar />
         <LiveTakeover />
+        <WelcomeIntro />
         <div className="relative z-20 flex flex-col min-h-dvh md:min-h-screen">
           <Header />
           <main className="flex-1">{children}</main>

--- a/components/WelcomeIntro.tsx
+++ b/components/WelcomeIntro.tsx
@@ -99,7 +99,7 @@ export default function WelcomeIntro() {
                 Welcome to
               </p>
               <h1 className="mt-2 text-3xl sm:text-4xl md:text-5xl font-semibold gradient-title">
-                Christ Like Ministries, Inc.
+                Christlike Ministries, Inc.
               </h1>
               <p className="mt-3 text-white/70">
                 We’re glad you’re here.


### PR DESCRIPTION
## Summary
- integrate WelcomeIntro component into root layout for a home-page overlay
- update intro text to greet visitors to Christlike Ministries, Inc.

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f8f538a4c832293d6b083c9786dbd