### PR TITLE
fix: allow scroll recovery on Edge

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -130,7 +130,7 @@ h3 { font-size: var(--h3); }
 }
 /* Reduce bounce revealing background beyond the page */
 html, body {
-  overscroll-behavior-y: none;      /* prevent overscroll bounce on mobile */
+  overscroll-behavior-y: contain;   /* avoid scroll lock on Edge while reducing bounce */
   overflow-x: hidden;               /* just in case */
   overflow-y: auto;                 /* allow normal vertical scrolling */
 }


### PR DESCRIPTION
## Summary
- avoid scroll lock in Edge by changing `overscroll-behavior-y` to `contain`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f927ade0c83229f82d7f24e50e782