### PR TITLE
fix: adapt Edge overscroll by device

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -130,8 +130,15 @@ h3 { font-size: var(--h3); }
 }
 /* Reduce bounce revealing background beyond the page */
 html, body {
-  overscroll-behavior-y: none;      /* prevent overscroll bounce on mobile */
+  overscroll-behavior-y: none;      /* prevent overscroll bounce on desktop */
   overflow-x: hidden;               /* just in case */
   overflow-y: auto;                 /* allow normal vertical scrolling */
+}
+
+/* Edge can lock scroll on touch devices; relax overscroll there */
+@media (max-width: 768px), (pointer: coarse) {
+  html, body {
+    overscroll-behavior-y: contain; /* avoid scroll lock while still damping bounce */
+  }
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -130,7 +130,7 @@ h3 { font-size: var(--h3); }
 }
 /* Reduce bounce revealing background beyond the page */
 html, body {
-  overscroll-behavior-y: none;      /* prevent overscroll bounce on desktop */
+  overscroll-behavior-y: none;      /*  prevent overscroll bounce on desktop */
   overflow-x: hidden;               /* just in case */
   overflow-y: auto;                 /* allow normal vertical scrolling */
 }


### PR DESCRIPTION
## Summary
- default overscroll-behavior-y to none on desktops
- relax overscroll on touch/small devices to avoid Edge scroll lock

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f927ade0c83229f82d7f24e50e782