### PR TITLE
Add scroll progress bar and back-to-top button

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,6 +11,8 @@ import { LiveTakeover } from "@/components/LiveTakeover";
 import PWA from "@/components/PWA";
 import WelcomeIntro from "@/components/WelcomeIntro";
 import Lightning from "@/components/Lightning";
+import ScrollProgress from "@/components/ScrollProgress";
+import ScrollToTop from "@/components/ScrollToTop";
 
 
 // ✅ Set a proper absolute base for OG/Twitter URLs
@@ -44,6 +46,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body>
         <Scenery />
         <Lightning />  {/* ⚡️ subtle, random strikes behind content */}
+        <ScrollProgress />
         <AnnouncementsBar />
         <LiveTakeover />
         <WelcomeIntro />
@@ -52,6 +55,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <main className="flex-1">{children}</main>
           <Footer />
         </div>
+        <ScrollToTop />
         <a href={process.env.NEXT_PUBLIC_GIVING_URL || "/give"} className="sticky-cta btn-primary">Give</a>
         <PWA />
         <UXEffects />

--- a/components/ScrollProgress.tsx
+++ b/components/ScrollProgress.tsx
@@ -1,0 +1,17 @@
+"use client";
+import { motion, useScroll, useSpring } from "framer-motion";
+
+export default function ScrollProgress() {
+  const { scrollYProgress } = useScroll();
+  const scaleX = useSpring(scrollYProgress, {
+    stiffness: 90,
+    damping: 30,
+    restDelta: 0.001,
+  });
+  return (
+    <motion.div
+      className="fixed top-0 left-0 right-0 h-1 bg-brand-600 origin-left z-[60]"
+      style={{ scaleX }}
+    />
+  );
+}

--- a/components/ScrollToTop.tsx
+++ b/components/ScrollToTop.tsx
@@ -1,0 +1,31 @@
+"use client";
+import { useEffect, useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { ArrowUp } from "lucide-react";
+
+export default function ScrollToTop() {
+  const [visible, setVisible] = useState(false);
+  useEffect(() => {
+    const onScroll = () => setVisible(window.scrollY > 400);
+    onScroll();
+    window.addEventListener("scroll", onScroll);
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+  return (
+    <AnimatePresence>
+      {visible && (
+        <motion.button
+          onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+          initial={{ opacity: 0, y: 80 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: 80 }}
+          transition={{ duration: 0.3 }}
+          className="fixed left-4 bottom-4 z-40 p-3 rounded-full bg-brand-600 text-white shadow-glow focus:outline-none focus-visible:ring-2 ring-brand-600"
+          aria-label="Scroll to top"
+        >
+          <ArrowUp size={20} />
+        </motion.button>
+      )}
+    </AnimatePresence>
+  );
+}


### PR DESCRIPTION
## Summary
- add animated scroll progress indicator using framer-motion
- include an animated scroll-to-top button
- wire new components into the root layout

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689fa9f74d6c8322a09acbae35c19e6a