### PR TITLE
Add animated border around countdown text

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -90,6 +90,30 @@ h3 { @apply text-2xl; }
 }
 .pill-animated { animation: pillPulse var(--dur,3s) ease-in-out infinite; }
 
+/* Animated rainbow trim around countdown text */
+.countdown-trim {
+  position: relative;
+  display: inline-block;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.375rem;
+}
+.countdown-trim::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  padding: 1px;
+  border-radius: inherit;
+  background: conic-gradient(from 0deg, #f87171, #fbbf24, #34d399, #60a5fa, #a78bfa, #f472b6, #f87171);
+  -webkit-mask: linear-gradient(#0000 0 0) content-box, linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+          mask-composite: exclude;
+  animation: countdown-trim-spin 8s linear infinite;
+  pointer-events: none;
+}
+@keyframes countdown-trim-spin {
+  to { transform: rotate(1turn); }
+}
+
 
 /* Hide horizontal scrollbar track for the sermon rail */
 .hide-scroll::-webkit-scrollbar{ display:none; }

--- a/components/LiveBadge.tsx
+++ b/components/LiveBadge.tsx
@@ -51,7 +51,7 @@ export function LiveBadge() {
       </span>
 
       {!live && (
-        <span className="text-white/70">
+        <span className="countdown-trim text-white/70">
           Next: Sun 10:00am CT · {countdown.days}d {countdown.hours}h {countdown.minutes}m
         </span>
       )}


### PR DESCRIPTION
## Summary
- animate rainbow trim around upcoming service countdown text
- expose countdown via `countdown-trim` CSS class

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689fb6aa4828832297f1b5939682ac5d