### PR TITLE
Add glowing pill around countdown text

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -90,6 +90,30 @@ h3 { @apply text-2xl; }
 }
 .pill-animated { animation: pillPulse var(--dur,3s) ease-in-out infinite; }
 
+/* Glowing highlight around countdown text */
+.countdown-pill {
+  position: relative;
+  display: inline-block;
+  padding: 0.25rem 0.5rem;
+  border-radius: 9999px;
+  background: rgba(255,255,255,0.1);
+  z-index: 0;
+}
+.countdown-pill::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: conic-gradient(#f87171, #fbbf24, #34d399, #60a5fa, #a78bfa, #f472b6, #f87171);
+  filter: blur(8px);
+  opacity: 0.7;
+  z-index: -1;
+  animation: countdown-pill-spin 8s linear infinite;
+}
+@keyframes countdown-pill-spin {
+  to { transform: rotate(1turn); }
+}
+
 
 /* Hide horizontal scrollbar track for the sermon rail */
 .hide-scroll::-webkit-scrollbar{ display:none; }

--- a/components/LiveBadge.tsx
+++ b/components/LiveBadge.tsx
@@ -51,7 +51,7 @@ export function LiveBadge() {
       </span>
 
       {!live && (
-        <span className="text-white/70">
+        <span className="countdown-pill text-white/70">
           Next: Sun 10:00am CT · {countdown.days}d {countdown.hours}h {countdown.minutes}m
         </span>
       )}


### PR DESCRIPTION
## Summary
- wrap upcoming service countdown in a pill-style container
- animate a rotating rainbow glow behind the countdown

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689fb6aa4828832297f1b5939682ac5d