### PR TITLE
Add Ansible configuration for home lab cluster

### DIFF
--- a/ansible/inventory.ini
+++ b/ansible/inventory.ini
@@ -1,0 +1,14 @@
+[master]
+m2 ansible_host=192.168.50.6
+m1 ansible_host=192.168.50.2
+m3 ansible_host=192.168.50.3
+
+[worker]
+w2 ansible_host=192.168.50.4
+w3 ansible_host=192.168.50.5
+w5 ansible_host=192.168.50.7
+
+[all:vars]
+ansible_user=wayne
+k3s_version=v1.29.4+k3s1
+cluster_vip=192.168.50.251

--- a/ansible/metallb-config.yaml
+++ b/ansible/metallb-config.yaml
@@ -1,0 +1,14 @@
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: default
+  namespace: metallb-system
+spec:
+  addresses:
+    - 192.168.50.241-192.168.50.253
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: default
+  namespace: metallb-system

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -1,0 +1,55 @@
+- hosts: master:worker
+  become: yes
+  tasks:
+    - name: Install dependencies
+      apt:
+        name:
+          - curl
+          - nfs-common
+          - open-iscsi
+        state: present
+    - name: Disable swap
+      command: swapoff -a
+      when: ansible_swaptotal_mb > 0
+
+- hosts: master
+  become: yes
+  roles:
+    - role: xanmanning.k3s
+      k3s_control_node: true
+      k3s_server:
+        write_kubeconfig_mode: "0644"
+        disable:
+          - servicelb
+          - traefik
+        tls_san:
+          - "{{ cluster_vip }}"
+
+- hosts: worker
+  become: yes
+  roles:
+    - role: xanmanning.k3s
+      k3s_agent: true
+
+- hosts: master[0]
+  become: yes
+  tasks:
+    - name: Apply kube-vip manifest
+      shell: |
+        export VIP="{{ cluster_vip }}"
+        export INTERFACE=eth0
+        curl -sL https://kube-vip.io/manifests/manifest.yaml \
+          | sed "s/VIP/$VIP/;s/INTERFACE/$INTERFACE/" \
+          | kubectl apply -f -
+    - name: Copy MetalLB configuration
+      copy:
+        src: metallb-config.yaml
+        dest: /tmp/metallb-config.yaml
+    - name: Install MetalLB
+      shell: |
+        kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.12/manifests/metallb-native.yaml
+        kubectl apply -f /tmp/metallb-config.yaml
+      args:
+        creates: /tmp/metallb-installed
+    - name: Install Longhorn
+      shell: kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v1.6.1/deploy/longhorn.yaml


### PR DESCRIPTION
## Summary
- add Ansible inventory for Raspberry Pi cluster with wayne user
- provision k3s HA cluster with kube-vip and Longhorn
- configure MetalLB to advertise 192.168.50.241-253 range

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f79345b04832289d70738662ff36e