### PR TITLE
Add CI workflow and Kubernetes manifests for dev and prod

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,50 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          platforms: linux/arm64
+          tags: ghcr.io/${{ github.repository_owner }}/clm-site:${{ github.sha }}
+
+  deploy-dev:
+    needs: build
+    if: github.ref != 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG }}" > ~/.kube/config
+          kubectl apply -f k8s/dev/deploy.yaml
+          kubectl set image deployment/clm-site clm-site=ghcr.io/${{ github.repository_owner }}/clm-site:${{ github.sha }} -n dev
+
+  deploy-prod:
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG }}" > ~/.kube/config
+          kubectl apply -f k8s/prod/deploy.yaml
+          kubectl set image deployment/clm-site clm-site=ghcr.io/${{ github.repository_owner }}/clm-site:${{ github.sha }} -n prod

--- a/ansible/inventory.ini
+++ b/ansible/inventory.ini
@@ -1,0 +1,14 @@
+[master]
+m2 ansible_host=192.168.50.6
+m1 ansible_host=192.168.50.2
+m3 ansible_host=192.168.50.3
+
+[worker]
+w2 ansible_host=192.168.50.4
+w3 ansible_host=192.168.50.5
+w5 ansible_host=192.168.50.7
+
+[all:vars]
+ansible_user=wayne
+k3s_version=v1.29.4+k3s1
+cluster_vip=192.168.50.251

--- a/ansible/metallb-config.yaml
+++ b/ansible/metallb-config.yaml
@@ -1,0 +1,14 @@
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: default
+  namespace: metallb-system
+spec:
+  addresses:
+    - 192.168.50.241-192.168.50.253
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: default
+  namespace: metallb-system

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -1,0 +1,55 @@
+- hosts: master:worker
+  become: yes
+  tasks:
+    - name: Install dependencies
+      apt:
+        name:
+          - curl
+          - nfs-common
+          - open-iscsi
+        state: present
+    - name: Disable swap
+      command: swapoff -a
+      when: ansible_swaptotal_mb > 0
+
+- hosts: master
+  become: yes
+  roles:
+    - role: xanmanning.k3s
+      k3s_control_node: true
+      k3s_server:
+        write_kubeconfig_mode: "0644"
+        disable:
+          - servicelb
+          - traefik
+        tls_san:
+          - "{{ cluster_vip }}"
+
+- hosts: worker
+  become: yes
+  roles:
+    - role: xanmanning.k3s
+      k3s_agent: true
+
+- hosts: master[0]
+  become: yes
+  tasks:
+    - name: Apply kube-vip manifest
+      shell: |
+        export VIP="{{ cluster_vip }}"
+        export INTERFACE=eth0
+        curl -sL https://kube-vip.io/manifests/manifest.yaml \
+          | sed "s/VIP/$VIP/;s/INTERFACE/$INTERFACE/" \
+          | kubectl apply -f -
+    - name: Copy MetalLB configuration
+      copy:
+        src: metallb-config.yaml
+        dest: /tmp/metallb-config.yaml
+    - name: Install MetalLB
+      shell: |
+        kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.12/manifests/metallb-native.yaml
+        kubectl apply -f /tmp/metallb-config.yaml
+      args:
+        creates: /tmp/metallb-installed
+    - name: Install Longhorn
+      shell: kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v1.6.1/deploy/longhorn.yaml

--- a/k8s/dev/deploy.yaml
+++ b/k8s/dev/deploy.yaml
@@ -1,0 +1,62 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dev
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: clm-site
+  namespace: dev
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: clm-site
+  template:
+    metadata:
+      labels:
+        app: clm-site
+    spec:
+      containers:
+        - name: clm-site
+          image: ghcr.io/wayne/clm-site:latest
+          ports:
+            - containerPort: 3000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: clm-site
+  namespace: dev
+spec:
+  type: ClusterIP
+  selector:
+    app: clm-site
+  ports:
+    - port: 80
+      targetPort: 3000
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: clm-site
+  namespace: dev
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-godaddy
+spec:
+  rules:
+    - host: dev.allenwmoorejr.org
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: clm-site
+                port:
+                  number: 80
+  tls:
+    - hosts:
+        - dev.allenwmoorejr.org
+      secretName: clm-site-tls

--- a/k8s/prod/deploy.yaml
+++ b/k8s/prod/deploy.yaml
@@ -1,0 +1,62 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: prod
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: clm-site
+  namespace: prod
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: clm-site
+  template:
+    metadata:
+      labels:
+        app: clm-site
+    spec:
+      containers:
+        - name: clm-site
+          image: ghcr.io/wayne/clm-site:latest
+          ports:
+            - containerPort: 3000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: clm-site
+  namespace: prod
+spec:
+  type: ClusterIP
+  selector:
+    app: clm-site
+  ports:
+    - port: 80
+      targetPort: 3000
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: clm-site
+  namespace: prod
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-godaddy
+spec:
+  rules:
+    - host: allenwmoorejr.org
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: clm-site
+                port:
+                  number: 80
+  tls:
+    - hosts:
+        - allenwmoorejr.org
+      secretName: clm-site-tls

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "node --test"
   },
   "engines": {
     "node": ">=18"

--- a/tests/basic.test.js
+++ b/tests/basic.test.js
@@ -1,0 +1,6 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+test('basic truth', () => {
+  assert.equal(1 + 1, 2);
+});


### PR DESCRIPTION
## Summary
- set up GitHub Actions workflow to build ARM64 image and deploy to k3s dev/prod
- add Kubernetes manifests for dev and prod namespaces
- restore `npm test` using Node's built-in runner and a sample test

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f79345b04832289d70738662ff36e