### PR TITLE
chore: add Dockerfile for container build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+Dockerfile
+.dockerignore
+node_modules
+npm-debug.log
+.next
+.git
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# syntax=docker/dockerfile:1
+
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+RUN npm prune --omit=dev
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=builder /app/package*.json ./
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/next.config.mjs ./next.config.mjs
+EXPOSE 3000
+CMD ["npm", "start"]


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfile for Next.js app
- ignore unnecessary files in Docker context

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Poppins`)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e9d77ab88322a4560a23ea57c41d