### PR TITLE
feat: highlight online status when live

### DIFF
--- a/components/HomeClient.tsx
+++ b/components/HomeClient.tsx
@@ -137,13 +137,13 @@ export default function HomeClient() {
                   <span
                     className={[
                       "inline-flex items-center gap-1.5 px-2 py-1 rounded-full",
-                      live?.live ? "bg-red-500/20 text-red-300" : "bg-white/10 text-white/70",
+                      live?.live ? "bg-red-500/20 text-red-300 shadow-glow" : "bg-white/10 text-white/70",
                       !live?.live && animated ? "pill-animated" : "",
                     ].join(" ")}
                     style={!live?.live ? ({ ["--dur" as any]: dur, ["--glow" as any]: glow } as any) : undefined}
                   >
                     <span className={`w-2 h-2 rounded-full ${live?.live ? "bg-red-400 animate-pulse" : "bg-white/40"}`} />
-                    {live?.live ? "LIVE" : "Offline"}
+                    {live?.live ? "Online" : "Offline"}
                   </span>
                 </motion.div>
               );

--- a/components/LiveBadge.tsx
+++ b/components/LiveBadge.tsx
@@ -41,13 +41,13 @@ export function LiveBadge() {
       <span
         className={[
           "inline-flex items-center gap-1.5 px-2 py-1 rounded-full",
-          live ? "bg-red-500/20 text-red-300" : "bg-white/10 text-white/70",
+          live ? "bg-red-500/20 text-red-300 shadow-glow" : "bg-white/10 text-white/70",
           !live && prox.animated ? "pill-animated" : ""
         ].join(" ")}
         style={!live ? ({ ["--dur" as any]: prox.dur, ["--glow" as any]: prox.glow } as any) : undefined}
       >
         <span className={`w-2 h-2 rounded-full ${live ? "bg-red-400 animate-pulse" : "bg-white/40"}`} />
-        {live ? "LIVE" : "Offline"}
+        {live ? "Online" : "Offline"}
       </span>
 
       {!live && (


### PR DESCRIPTION
## Summary
- show "Online" instead of "Offline" when stream is live
- add glowing highlight to live status badge

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1fae7ea24832293efbafadb93e564