### PR TITLE
Add CI workflow and Kubernetes manifests for dev and prod

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,50 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          platforms: linux/arm64
+          tags: ghcr.io/${{ github.repository_owner }}/clm-site:${{ github.sha }}
+
+  deploy-dev:
+    needs: build
+    if: github.ref != 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG }}" > ~/.kube/config
+          kubectl apply -f k8s/dev/deploy.yaml
+          kubectl set image deployment/clm-site clm-site=ghcr.io/${{ github.repository_owner }}/clm-site:${{ github.sha }} -n dev
+
+  deploy-prod:
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG }}" > ~/.kube/config
+          kubectl apply -f k8s/prod/deploy.yaml
+          kubectl set image deployment/clm-site clm-site=ghcr.io/${{ github.repository_owner }}/clm-site:${{ github.sha }} -n prod

--- a/ansible/inventory.ini
+++ b/ansible/inventory.ini
@@ -1,0 +1,14 @@
+[master]
+m2 ansible_host=192.168.50.6
+m1 ansible_host=192.168.50.2
+m3 ansible_host=192.168.50.3
+
+[worker]
+w2 ansible_host=192.168.50.4
+w3 ansible_host=192.168.50.5
+w5 ansible_host=192.168.50.7
+
+[all:vars]
+ansible_user=wayne
+k3s_version=v1.29.4+k3s1
+cluster_vip=192.168.50.251

--- a/ansible/metallb-config.yaml
+++ b/ansible/metallb-config.yaml
@@ -1,0 +1,14 @@
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: default
+  namespace: metallb-system
+spec:
+  addresses:
+    - 192.168.50.241-192.168.50.253
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: default
+  namespace: metallb-system

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -1,0 +1,55 @@
+- hosts: master:worker
+  become: yes
+  tasks:
+    - name: Install dependencies
+      apt:
+        name:
+          - curl
+          - nfs-common
+          - open-iscsi
+        state: present
+    - name: Disable swap
+      command: swapoff -a
+      when: ansible_swaptotal_mb > 0
+
+- hosts: master
+  become: yes
+  roles:
+    - role: xanmanning.k3s
+      k3s_control_node: true
+      k3s_server:
+        write_kubeconfig_mode: "0644"
+        disable:
+          - servicelb
+          - traefik
+        tls_san:
+          - "{{ cluster_vip }}"
+
+- hosts: worker
+  become: yes
+  roles:
+    - role: xanmanning.k3s
+      k3s_agent: true
+
+- hosts: master[0]
+  become: yes
+  tasks:
+    - name: Apply kube-vip manifest
+      shell: |
+        export VIP="{{ cluster_vip }}"
+        export INTERFACE=eth0
+        curl -sL https://kube-vip.io/manifests/manifest.yaml \
+          | sed "s/VIP/$VIP/;s/INTERFACE/$INTERFACE/" \
+          | kubectl apply -f -
+    - name: Copy MetalLB configuration
+      copy:
+        src: metallb-config.yaml
+        dest: /tmp/metallb-config.yaml
+    - name: Install MetalLB
+      shell: |
+        kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.12/manifests/metallb-native.yaml
+        kubectl apply -f /tmp/metallb-config.yaml
+      args:
+        creates: /tmp/metallb-installed
+    - name: Install Longhorn
+      shell: kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v1.6.1/deploy/longhorn.yaml

--- a/app/globals.css
+++ b/app/globals.css
@@ -111,6 +111,11 @@ h3 { @apply text-2xl; }
   animation: countdown-pill-spin 8s linear infinite;
 }
 
+@keyframes countdown-pill-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
 /* Hide horizontal scrollbar track for the sermon rail */
 .hide-scroll::-webkit-scrollbar{ display:none; }
 .hide-scroll{ -ms-overflow-style:none; scrollbar-width:none; }

--- a/app/prayer/PrayerForm.tsx
+++ b/app/prayer/PrayerForm.tsx
@@ -1,0 +1,54 @@
+'use client'
+import { useState } from 'react'
+
+export default function PrayerForm(){
+  const [name,setName] = useState('')
+  const [request,setRequest] = useState('')
+  const [status,setStatus] = useState<'idle'|'loading'|'success'|'error'>('idle')
+
+  async function handleSubmit(e: React.FormEvent){
+    e.preventDefault()
+    setStatus('loading')
+    try{
+      const res = await fetch('/api/prayer',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({name,request})})
+      if(res.ok){
+        setStatus('success')
+        setName('')
+        setRequest('')
+      }else{
+        setStatus('error')
+      }
+    }catch{
+      setStatus('error')
+    }
+  }
+
+  return(
+    <div className="container py-24">
+      <h1 className="text-center gradient-title mb-4">Prayer Request</h1>
+      <p className="text-center text-white/70 mb-10 max-w-2xl mx-auto">We would be honored to pray with you. Share your request below and our pastor will receive it instantly.</p>
+      <form onSubmit={handleSubmit} className="max-w-lg mx-auto card p-8 flex flex-col gap-4">
+        <input
+          value={name}
+          onChange={e=>setName(e.target.value)}
+          required
+          placeholder="Your name"
+          className="bg-white/5 border border-white/10 rounded-xl px-4 py-3 focus:outline-none focus:border-brand-500"
+        />
+        <textarea
+          value={request}
+          onChange={e=>setRequest(e.target.value)}
+          required
+          placeholder="How can we pray for you?"
+          rows={5}
+          className="bg-white/5 border border-white/10 rounded-xl px-4 py-3 focus:outline-none focus:border-brand-500 resize-none"
+        />
+        <button type="submit" disabled={status==='loading'} className="btn-primary tap-target">
+          {status==='loading' ? 'Sending…' : 'Send Request'}
+        </button>
+        {status==='success' && <p className="text-green-400 text-sm">Thanks! Your request has been sent.</p>}
+        {status==='error' && <p className="text-red-500 text-sm">Something went wrong. Please try again.</p>}
+      </form>
+    </div>
+  )
+}

--- a/app/prayer/page.tsx
+++ b/app/prayer/page.tsx
@@ -1,56 +1,7 @@
-'use client'
-import { useState } from 'react'
-
-export default function PrayerPage(){
-  const [name,setName] = useState('')
-  const [request,setRequest] = useState('')
-  const [status,setStatus] = useState<'idle'|'loading'|'success'|'error'>('idle')
-
-  async function handleSubmit(e: React.FormEvent){
-    e.preventDefault()
-    setStatus('loading')
-    try{
-      const res = await fetch('/api/prayer',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({name,request})})
-      if(res.ok){
-        setStatus('success')
-        setName('')
-        setRequest('')
-      }else{
-        setStatus('error')
-      }
-    }catch{
-      setStatus('error')
-    }
-  }
-
-  return(
-    <div className="container py-24">
-      <h1 className="text-center gradient-title mb-4">Prayer Request</h1>
-      <p className="text-center text-white/70 mb-10 max-w-2xl mx-auto">We would be honored to pray with you. Share your request below and our pastor will receive it instantly.</p>
-      <form onSubmit={handleSubmit} className="max-w-lg mx-auto card p-8 flex flex-col gap-4">
-        <input
-          value={name}
-          onChange={e=>setName(e.target.value)}
-          required
-          placeholder="Your name"
-          className="bg-white/5 border border-white/10 rounded-xl px-4 py-3 focus:outline-none focus:border-brand-500"
-        />
-        <textarea
-          value={request}
-          onChange={e=>setRequest(e.target.value)}
-          required
-          placeholder="How can we pray for you?"
-          rows={5}
-          className="bg-white/5 border border-white/10 rounded-xl px-4 py-3 focus:outline-none focus:border-brand-500 resize-none"
-        />
-        <button type="submit" disabled={status==='loading'} className="btn-primary tap-target">
-          {status==='loading' ? 'Sending…' : 'Send Request'}
-        </button>
-        {status==='success' && <p className="text-green-400 text-sm">Thanks! Your request has been sent.</p>}
-        {status==='error' && <p className="text-red-500 text-sm">Something went wrong. Please try again.</p>}
-      </form>
-    </div>
-  )
-}
+import PrayerForm from './PrayerForm'
 
 export const metadata = { title: 'Prayer Request' }
+
+export default function PrayerPage(){
+  return <PrayerForm />
+}

--- a/k8s/dev/deploy.yaml
+++ b/k8s/dev/deploy.yaml
@@ -1,0 +1,62 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dev
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: clm-site
+  namespace: dev
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: clm-site
+  template:
+    metadata:
+      labels:
+        app: clm-site
+    spec:
+      containers:
+        - name: clm-site
+          image: ghcr.io/wayne/clm-site:latest
+          ports:
+            - containerPort: 3000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: clm-site
+  namespace: dev
+spec:
+  type: ClusterIP
+  selector:
+    app: clm-site
+  ports:
+    - port: 80
+      targetPort: 3000
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: clm-site
+  namespace: dev
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-godaddy
+spec:
+  rules:
+    - host: dev.allenwmoorejr.org
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: clm-site
+                port:
+                  number: 80
+  tls:
+    - hosts:
+        - dev.allenwmoorejr.org
+      secretName: clm-site-tls

--- a/k8s/prod/deploy.yaml
+++ b/k8s/prod/deploy.yaml
@@ -1,0 +1,62 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: prod
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: clm-site
+  namespace: prod
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: clm-site
+  template:
+    metadata:
+      labels:
+        app: clm-site
+    spec:
+      containers:
+        - name: clm-site
+          image: ghcr.io/wayne/clm-site:latest
+          ports:
+            - containerPort: 3000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: clm-site
+  namespace: prod
+spec:
+  type: ClusterIP
+  selector:
+    app: clm-site
+  ports:
+    - port: 80
+      targetPort: 3000
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: clm-site
+  namespace: prod
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-godaddy
+spec:
+  rules:
+    - host: allenwmoorejr.org
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: clm-site
+                port:
+                  number: 80
+  tls:
+    - hosts:
+        - allenwmoorejr.org
+      secretName: clm-site-tls

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "node --test"
   },
   "engines": {
     "node": ">=18"

--- a/tests/basic.test.js
+++ b/tests/basic.test.js
@@ -1,0 +1,6 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+test('basic truth', () => {
+  assert.equal(1 + 1, 2);
+});


### PR DESCRIPTION
## Summary
- set up GitHub Actions workflow to build ARM64 image and deploy to k3s dev/prod
- add Kubernetes manifests for dev and prod namespaces
- restore `npm test` using Node's built-in runner and a sample test
- fix Next.js build error by moving prayer page logic into a client component and exporting metadata from the server page
- add missing `countdown-pill-spin` keyframes to prevent CSS parse error

## Testing
- `npm run build`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f79345b04832289d70738662ff36e