### PR TITLE
Modernize homepage message and typography

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,6 +13,9 @@ import WelcomeIntro from "@/components/WelcomeIntro";
 import Lightning from "@/components/Lightning";
 import ScrollProgress from "@/components/ScrollProgress";
 import ScrollToTop from "@/components/ScrollToTop";
+import { Poppins } from "next/font/google";
+
+const poppins = Poppins({ subsets: ["latin"], weight: ["400", "600"] });
 
 
 // ✅ Set a proper absolute base for OG/Twitter URLs
@@ -43,7 +46,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <head>{/* … */}</head>
-      <body>
+      <body className={poppins.className}>
         <Scenery />
         <Lightning />  {/* ⚡️ subtle, random strikes behind content */}
         <ScrollProgress />

--- a/components/HomeClient.tsx
+++ b/components/HomeClient.tsx
@@ -161,10 +161,10 @@ export default function HomeClient() {
             <motion.p
               {...fadeUp}
               transition={{ ...fadeUp.transition, delay: 0.1 }}
-              className="mt-6 text-white/80 max-w-2xl"
+              className="mt-6 max-w-2xl text-lg sm:text-xl text-white/80 font-light leading-relaxed"
             >
-              Teaching saved people how to stay saved — and sharing Jesus with the world. Watch live, explore past sermons,
-              or send a prayer request.
+              Preaching the gospel to the world in hopes that many will be saved. Teaching the saved how to stay saved. Watch
+              live, explore past sermons, or send a prayer request.
             </motion.p>
 
             <motion.div


### PR DESCRIPTION
## Summary
- refresh hero message with new gospel-focused copy and larger, lighter styling
- apply Poppins font site-wide for a more modern feel

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1d8920174832297ce5f98d96e5e4d