### PR TITLE
Add site logo and show in header

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import type { Route } from "next";
 import { usePathname } from "next/navigation";
+import NextImage from "next/image";
 import { motion, AnimatePresence } from "framer-motion";
 import { LiveBadge } from "@/components/LiveBadge";
 import { Menu, X } from "lucide-react";
@@ -32,9 +33,13 @@ export function Header() {
       ${scrolled ? "backdrop-blur bg-white/5 border-b border-white/10" : "backdrop-blur supports-[backdrop-filter]:bg-white/5 border-b border-white/10"}`}>
       <div className="container flex items-center justify-between h-16">
         {/* Brand */}
-        <Link href={"/" as Route} className="font-semibold tracking-tight text-lg focus:outline-none focus-visible:ring-2 ring-brand-600 rounded-xl px-1">
+        <Link
+          href={"/" as Route}
+          className="flex items-center gap-2 font-semibold tracking-tight text-lg focus:outline-none focus-visible:ring-2 ring-brand-600 rounded-xl px-1"
+        >
+          <NextImage src="/logo.svg" alt="CLM logo" width={32} height={32} />
           <span className="gradient-title">CLM</span>
-          <span className="text-white/60 ml-2 text-sm">Christ Like Ministries</span>
+          <span className="text-white/60 text-sm">Christ Like Ministries</span>
         </Link>
 
         {/* Desktop nav */}

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,10 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grad" x1="0" y1="0" x2="32" y2="32" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#6366f1" />
+      <stop offset="100%" stop-color="#22d3ee" />
+    </linearGradient>
+  </defs>
+  <rect width="32" height="32" rx="8" fill="url(#grad)" />
+  <text x="16" y="21" text-anchor="middle" font-family="sans-serif" font-size="14" fill="white" font-weight="bold">CLM</text>
+</svg>


### PR DESCRIPTION
## Summary
- add simple gradient logo SVG
- display logo in header via Next.js image

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a22b56485c8322b4fddf35167195d6